### PR TITLE
Fix usb for nrf52 and stm32

### DIFF
--- a/src/xinput.rs
+++ b/src/xinput.rs
@@ -245,6 +245,10 @@ impl<'d, D: Driver<'d>> XInput<'d, D> {
         let mut idle_msg_deadline = Instant::MAX;
 
         loop {
+            #[cfg(feature = "defmt")]
+            debug!("Waiting for connection");
+            self.ep_in.wait_enabled().await;
+            self.ep_out.wait_enabled().await;
             match select3(
                 self.state.xinput.wait(),
                 Timer::at(idle_msg_deadline),


### PR DESCRIPTION
RP2040's USB impl is a bit more forgiving in what it will accept.
This wasn't working at all for stm32 and nrf52.

Add wait for USB endpoints in case they aren't ready yet - if this isn't here and we're logging failures and continuing, we get a lot of logs!

For my use-cases, if the USB interface isn't working there's not really a good way to recover it. So instead of panicking on error, we just log it.
I think this should work okay for battery powered device unplug->replug but that should be tested. It's not something I'm intending on using though, so maybe someone else could do that? 